### PR TITLE
Fix: enable_machine_learning option in aws_managed_rules_bot_control_rule_set

### DIFF
--- a/examples/wafv2-ip-rules/main.tf
+++ b/examples/wafv2-ip-rules/main.tf
@@ -201,6 +201,21 @@ module "waf" {
         metric_name                = "test-waf-setup-waf-ip-set-block-metrics"
         sampled_requests_enabled   = false
       }
+    },
+    {
+      name     = "ip-rate-limit-wo-scope-down-statement"
+      priority = "7"
+      action   = "count"
+
+      rate_based_statement = {
+        limit              = 1000
+        aggregate_key_type = "IP"
+      }
+
+      visibility_config = {
+        cloudwatch_metrics_enabled = false
+        sampled_requests_enabled   = false
+      }
     }
   ]
 

--- a/examples/wafv2-logging-configuration/variables.tf
+++ b/examples/wafv2-logging-configuration/variables.tf
@@ -1,0 +1,5 @@
+variable "name_prefix" {
+  description = "A prefix used for naming resources."
+  type        = string
+  default     = "example"
+}

--- a/examples/wafv2-sizeconstraint-rules/main.tf
+++ b/examples/wafv2-sizeconstraint-rules/main.tf
@@ -34,7 +34,7 @@ module "waf" {
       managed_rule_group_statement = {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
-        version     = "Version_2.0"
+        version     = "Version_1.6"
       }
     },
     {

--- a/main.tf
+++ b/main.tf
@@ -2551,7 +2551,7 @@ resource "aws_wafv2_web_acl" "main" {
             }
 
             dynamic "scope_down_statement" {
-              for_each = contains(keys(rate_based_statement.value), "scope_down_statement") && rate_based_statement.value["scope_down_statement"] != null ? [lookup(rate_based_statement.value, "scope_down_statement", {})] : []
+              for_each = length(lookup(rate_based_statement.value, "scope_down_statement", {})) == 0 ? [] : [lookup(rate_based_statement.value, "scope_down_statement", {})]
               content {
                 # scope down byte_match_statement
                 dynamic "byte_match_statement" {
@@ -2817,7 +2817,7 @@ resource "aws_wafv2_web_acl" "main" {
 
                 # scope down ip_set_reference_statement
                 dynamic "ip_set_reference_statement" {
-                  for_each = contains(keys(scope_down_statement.value), "ip_set_reference_statement") && scope_down_statement.value["ip_set_reference_statement"] != null ? [lookup(scope_down_statement.value, "ip_set_reference_statement", {})] : []
+                  for_each = length(lookup(scope_down_statement.value, "ip_set_reference_statement", {})) == 0 ? [] : [lookup(scope_down_statement.value, "ip_set_reference_statement", {})]
                   content {
                     arn = lookup(ip_set_reference_statement.value, "arn")
                     dynamic "ip_set_forwarded_ip_config" {

--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,7 @@ resource "aws_wafv2_web_acl" "main" {
                   for_each = length(lookup(managed_rule_group_configs.value, "aws_managed_rules_bot_control_rule_set", {})) == 0 ? [] : [lookup(managed_rule_group_configs.value, "aws_managed_rules_bot_control_rule_set", {})]
                   content {
                     inspection_level = lookup(aws_managed_rules_bot_control_rule_set.value, "inspection_level")
+                    enable_machine_learning = lookup(aws_managed_rules_bot_control_rule_set.value, "enable_machine_learning")
                   }
                 }
               }

--- a/test/waf_webaclv2_and_or_test.go
+++ b/test/waf_webaclv2_and_or_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2AndOr(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "714")
-	assert.Equal(t, WebAclRuleNames, "block-specific-ip-set-or-body-contains-hotmail, block-specific-uri-path-and-requests-from-nl-gb-and-us, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "760", WebAclCapacity)
+	assert.Equal(t, "[block-specific-ip-set-or-body-contains-hotmail block-specific-uri block-specific-uri-path-and-not-requests-from-nl-gb-and-us block-specific-uri-path-and-requests-from-nl-gb-and-us AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_bytematch_test.go
+++ b/test/waf_webaclv2_bytematch_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2Bytematch(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "736")
-	assert.Equal(t, WebAclRuleNames, "block-all-post-requests, block-if-request-body-contains-hotmail-email, block-single-user, block-specific-uri-path, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "756", WebAclCapacity)
+	assert.Equal(t, "[block-all-post-requests block-cookie block-if-request-body-contains-hotmail-email block-single-user block-specific-uri-path block-unauthorized AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_geomatch_test.go
+++ b/test/waf_webaclv2_geomatch_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2Geomatch(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "701")
-	assert.Equal(t, WebAclRuleNames, "allow-nl-gb-us-traffic-only, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "701", WebAclCapacity)
+	assert.Equal(t, "[allow-nl-gb-us-traffic-only AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_ip_rules_test.go
+++ b/test/waf_webaclv2_ip_rules_test.go
@@ -47,12 +47,12 @@ func TestWafWebAclV2IpRules(t *testing.T) {
 	CustomIpSetArn := terraform.Output(t, terraformOptions, "custom_ip_set_arn")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "721")
-	assert.Equal(t, WebAclRuleNames, "block-ip-set, allow-custom-ip-set, ip-rate-limit, ip-rate-limit-with-or-scope-down, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "728", WebAclCapacity)
+	assert.Equal(t, "[block-ip-set allow-custom-ip-set allow-custom-ip-set-with-XFF-header ip-rate-limit ip-rate-limit-with-or-scope-down ip-rate-limit-wo-scope-down-statement AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 	assert.Contains(t, BlockIpSetArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, BlockIpSetArn, "regional/ipset/test"+uniqueID+"-generated-ips")
 	assert.Contains(t, CustomIpSetArn, "arn:aws:wafv2:eu-west-1:")

--- a/test/waf_webaclv2_label_match_test.go
+++ b/test/waf_webaclv2_label_match_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2Labelmatch(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "61")
-	assert.Equal(t, WebAclRuleNames, "block-specific-agent, AWSManagedRulesBotControlRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "61", WebAclCapacity)
+	assert.Equal(t, "[block-specific-agent AWSManagedRulesBotControlRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_logging_config_test.go
+++ b/test/waf_webaclv2_logging_config_test.go
@@ -1,17 +1,29 @@
 package test
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWafWebAclV2Logging(t *testing.T) {
+	// Random generate a string for naming resources
+	uniqueID := strings.ToLower(random.UniqueId())
+	resourceName := fmt.Sprintf("test%s", uniqueID)
+
 	// retryable errors in terraform testing.
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/wafv2-logging-configuration",
 		Upgrade:      true,
+
+		// Variables to pass using -var-file option
+		Vars: map[string]interface{}{
+			"name_prefix": resourceName,
+		},
 	})
 
 	// At the end of the test, run `terraform destroy` to clean up any resources that were created
@@ -51,39 +63,39 @@ func TestWafWebAclV2Logging(t *testing.T) {
 	S3BucketId := terraform.Output(t, terraformOptions, "logging_s3_bucket_id")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test-waf-setup")
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
-	assert.Contains(t, WebAclArn, "regional/webacl/test-waf-setup")
-	assert.Equal(t, WebAclVisConfigMetricName, "test-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "950")
-	assert.Equal(t, WebAclRuleNames, "AWSManagedRulesCommonRuleSet-rule-1, AWSManagedRulesKnownBadInputsRuleSet-rule-2, AWSManagedRulesPHPRuleSet-rule-3")
+	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "950", WebAclCapacity)
+	assert.Equal(t, "[AWSManagedRulesCommonRuleSet-rule-1 AWSManagedRulesKnownBadInputsRuleSet-rule-2 AWSManagedRulesPHPRuleSet-rule-3]", WebAclRuleNames)
 
 	assert.Contains(t, WebAclAssociationId, "arn:aws:wafv2:eu-west-1")
-	assert.Contains(t, WebAclAssociationId, "regional/webacl/test-waf-setup")
+	assert.Contains(t, WebAclAssociationId, "regional/webacl/"+resourceName)
 	assert.Contains(t, WebAclAssociationResourceArn, "arn:aws:elasticloadbalancing:eu-west-1")
-	assert.Contains(t, WebAclAssociationResourceArn, "loadbalancer/app/alb-waf-example")
+	assert.Contains(t, WebAclAssociationResourceArn, "loadbalancer/app/"+resourceName+"-alb-waf-example")
 	assert.Contains(t, WebAclAssociationAclArn, "arn:aws:wafv2:eu-west-1:")
-	assert.Contains(t, WebAclAssociationAclArn, "regional/webacl/test-waf-setup")
+	assert.Contains(t, WebAclAssociationAclArn, "regional/webacl/"+resourceName)
 
 	assert.Contains(t, WebAclAssociationAlbListId, "arn:aws:wafv2:eu-west-1")
-	assert.Contains(t, WebAclAssociationAlbListId, "regional/webacl/test-waf-setup")
+	assert.Contains(t, WebAclAssociationAlbListId, "regional/webacl/"+resourceName)
 	assert.Contains(t, WebAclAssociationAlbListResourceArn, "arn:aws:elasticloadbalancing:eu-west-1")
-	assert.Contains(t, WebAclAssociationAlbListResourceArn, "loadbalancer/app/alb-waf-example")
+	assert.Contains(t, WebAclAssociationAlbListResourceArn, "loadbalancer/app/"+resourceName+"-alb-waf-example")
 	assert.Contains(t, WebAclAssociationAlbListAclArn, "arn:aws:wafv2:eu-west-1:")
-	assert.Contains(t, WebAclAssociationAlbListAclArn, "regional/webacl/test-waf-setup")
+	assert.Contains(t, WebAclAssociationAlbListAclArn, "regional/webacl/"+resourceName)
 
 	assert.Contains(t, KinesisStreamArn, "arn:aws:firehose:eu-west-1")
 	assert.Contains(t, KinesisStreamArn, "deliverystream/aws-waf-logs-kinesis-firehose-test-stream")
 
 	assert.Contains(t, IamRoleArn, "arn:aws:iam::")
 	assert.Contains(t, IamRoleArn, "role/firehose-stream-test-role")
-	assert.Equal(t, IamRoleId, "firehose-stream-test-role")
-	assert.Equal(t, IamRoleName, "firehose-stream-test-role")
+	assert.Equal(t, "firehose-stream-test-role", IamRoleId)
+	assert.Equal(t, "firehose-stream-test-role", IamRoleName)
 
-	assert.Equal(t, IamRolePolicyId, "firehose-stream-test-role:firehose-role-custom-policy")
-	assert.Equal(t, IamRolePolicyName, "firehose-role-custom-policy")
-	assert.Equal(t, IamRolePolicyRole, "firehose-stream-test-role")
+	assert.Equal(t, "firehose-stream-test-role:firehose-role-custom-policy", IamRolePolicyId)
+	assert.Equal(t, "firehose-role-custom-policy", IamRolePolicyName)
+	assert.Equal(t, "firehose-stream-test-role", IamRolePolicyRole)
 
-	assert.Equal(t, S3BucketArn, "arn:aws:s3:::aws-waf-firehose-stream-test-bucket")
-	assert.Equal(t, S3BucketId, "aws-waf-firehose-stream-test-bucket")
+	assert.Equal(t, "arn:aws:s3:::test"+uniqueID+"-aws-waf-firehose-stream-test-bucket", S3BucketArn)
+	assert.Equal(t, "test"+uniqueID+"-aws-waf-firehose-stream-test-bucket", S3BucketId)
 }

--- a/test/waf_webaclv2_regex_pattern_test.go
+++ b/test/waf_webaclv2_regex_pattern_test.go
@@ -47,13 +47,13 @@ func TestWafWebAclV2RegexPattern(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "35")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "35", WebAclCapacity)
 	assert.Contains(t, BadBotsRegexArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, BadBotsRegexArn, "regional/regexpatternset/BadBotsUserAgent/")
-	assert.Equal(t, BadBotsRegexName, "BadBotsUserAgent")
-	assert.Equal(t, WebAclRuleNames, "MatchRegexRule-1")
+	assert.Equal(t, "BadBotsUserAgent", BadBotsRegexName)
+	assert.Equal(t, "[MatchRegexRule-1]", WebAclRuleNames)
 }

--- a/test/waf_webaclv2_sizeconstraint_test.go
+++ b/test/waf_webaclv2_sizeconstraint_test.go
@@ -43,10 +43,10 @@ func TestWafWebAclV2Sizeconstraint(t *testing.T) {
 	WebAclRuleNames := terraform.Output(t, terraformOptions, "web_acl_rule_names")
 
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, WebAclName, "test"+uniqueID)
+	assert.Equal(t, "test"+uniqueID, WebAclName)
 	assert.Contains(t, WebAclArn, "arn:aws:wafv2:eu-west-1:")
 	assert.Contains(t, WebAclArn, "regional/webacl/test"+uniqueID)
-	assert.Equal(t, WebAclVisConfigMetricName, "test"+uniqueID+"-waf-setup-waf-main-metrics")
-	assert.Equal(t, WebAclCapacity, "737")
-	assert.Equal(t, WebAclRuleNames, "BodySizeConstraint, block-all-post-requests, block-if-request-body-contains-hotmail-email, block-single-user, block-specific-uri-path, AWSManagedRulesCommonRuleSet-rule-1")
+	assert.Equal(t, "test"+uniqueID+"-waf-setup-waf-main-metrics", WebAclVisConfigMetricName)
+	assert.Equal(t, "737", WebAclCapacity)
+	assert.Equal(t, "[BodySizeConstraint block-all-post-requests block-if-request-body-contains-hotmail-email block-single-user block-specific-uri-path AWSManagedRulesCommonRuleSet-rule-1]", WebAclRuleNames)
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.52.0"
+      version = ">= 5.60.0"
     }
   }
 }


### PR DESCRIPTION
### Description
Fixes [#139](https://github.com/umotif-public/terraform-aws-waf-webaclv2/issues/139)

- adding/fixing enable_machine_learning option for aws_managed_rules_bot_control_rule_set